### PR TITLE
Feature/analytical gkp states

### DIFF
--- a/jaxquantum/codes/gkp.py
+++ b/jaxquantum/codes/gkp.py
@@ -123,9 +123,13 @@ class GKPQubit(BosonicQubit):
 
         Adapted from code by Lev-Arcady Sellem <lev-arcady.sellem@inria.fr>
         """
-        truncat_series = 100
 
-        
+        # We choose the truncation of our series summation such that we
+        # capture 6 sigmas of the envelope.
+        # delta * (truncat_series*2*sqrt(pi)) = 6
+
+
+        truncat_series = max(3, int(6 / delta / 2 / jnp.sqrt(jnp.pi)))
 
         q_points = jnp.sqrt(jnp.pi) * (2 * jnp.arange(truncat_series) + mu)
 

--- a/jaxquantum/codes/gkp.py
+++ b/jaxquantum/codes/gkp.py
@@ -3,6 +3,7 @@ Cat Code Qubit
 """
 
 from typing import Tuple
+import warnings
 
 from jaxquantum.codes.base import BosonicQubit
 import jaxquantum as jqt
@@ -113,7 +114,7 @@ class GKPQubit(BosonicQubit):
         return q_quad
 
     @staticmethod
-    def _compute_gkp_basis_z(delta, dim, mu):
+    def _compute_gkp_basis_z(delta, dim, mu, series_trunc=100):
         """
         Args:
             mu: state index (0 or 1)
@@ -125,13 +126,13 @@ class GKPQubit(BosonicQubit):
         """
 
         # We choose the truncation of our series summation such that we
-        # capture 6 sigmas of the envelope.
+        # capture 6 sigmas of the envelope for a value of delta of 0.02.
         # delta * (truncat_series*2*sqrt(pi)) = 6
 
+        
 
-        truncat_series = max(3, int(6 / delta / 2 / jnp.sqrt(jnp.pi)))
 
-        q_points = jnp.sqrt(jnp.pi) * (2 * jnp.arange(truncat_series) + mu)
+        q_points = jnp.sqrt(jnp.pi) * (2 * jnp.arange(series_trunc) + mu)
 
         def compute_pop(n):
             quadvals = GKPQubit._q_quadrature(q_points, n)
@@ -158,6 +159,9 @@ class GKPQubit(BosonicQubit):
 
         delta = self.params["delta"]
         dim = self.params["N"]
+
+        if delta<0.02:
+            warnings.warn("State preparation with delta values lower than 0.02 might lead to loss of accuracy.")
         
         jitted_compute_gkp_basis_z = jit(self._compute_gkp_basis_z, 
                                          static_argnames=("dim",))

--- a/jaxquantum/codes/gkp.py
+++ b/jaxquantum/codes/gkp.py
@@ -6,7 +6,10 @@ from typing import Tuple
 
 from jaxquantum.codes.base import BosonicQubit
 import jaxquantum as jqt
-
+from functools import partial
+from jax import jit, lax
+from jax.nn import one_hot
+from jax.scipy.special import gammaln
 import jax.numpy as jnp
 
 
@@ -81,41 +84,169 @@ class GKPQubit(BosonicQubit):
             1.0j * self.params["l"] * y_axis
         )
 
+    def _log_hermite(self, n, xs):
+        float_dtype = xs.dtype
+
+        def n_is_zero_branch(_xs):
+            return jnp.ones_like(_xs, dtype=jnp.int32), jnp.zeros_like(_xs,
+                                                                       dtype=float_dtype)
+
+        def n_is_not_zero_branch(_xs):
+            zeros = self.hermroots(n, n + 1).astype(float_dtype)
+            xs_minus_zeros = _xs[:, None] - zeros[None, :]
+            num_negative_factors = (xs_minus_zeros < 0).sum(axis=1)
+            signs = (1 - 2 * (num_negative_factors % 2))
+            abs_xs_minus_zeros = jnp.abs(xs_minus_zeros)
+            log_of_2 = jnp.log(jnp.array(2.0, dtype=float_dtype))
+            log_abs = n * log_of_2 + jnp.log(abs_xs_minus_zeros).sum(axis=1)
+
+            return signs.astype(jnp.int32), log_abs.astype(float_dtype)
+
+        return lax.cond(n == 0, n_is_zero_branch, n_is_not_zero_branch,
+                            operand=xs)
+
+    def _log_ho_basis_prefactors(self, n, xs):
+        return (-n / 2.0 * jnp.log(2.0)
+                - 0.5 * gammaln(n + 1.0)
+                - 0.25 * jnp.log(jnp.pi)
+                - xs ** 2 / 2.0)
+
+    def _log_ho_basis_function(self, n, xs):
+        signs_herm, log_abs_herm = self._log_hermite(n, xs)
+        log_prefactors = self._log_ho_basis_prefactors(n, xs)
+        return signs_herm, log_abs_herm + log_prefactors
+
+
+    def _calculate_single_amplitude(self, n, xs, delta):
+        logenv = -delta ** 2 * n
+        sgns, logamps = self._log_ho_basis_function(n, xs)
+        amps = sgns * jnp.exp(logenv + logamps)
+        return amps.sum()
+
+    def _finite_gkp(self, mu, delta, dim):
+        """
+        Constructs a finite-energy GKP state in the Fock basis.
+        """
+        l = 2.0 * jnp.sqrt(jnp.pi)
+        xs = l * (jnp.arange(-5000, 5001, dtype=jnp.float64) + mu / 2.0)
+
+        amplitudes = []
+        for n in range(dim):
+            amp = self._calculate_single_amplitude(n, xs, delta)
+            amplitudes.append(amp)
+
+        amplitudes = jnp.array(amplitudes)
+
+        norm = jnp.linalg.norm(amplitudes)
+        normalized_amplitudes = amplitudes / (norm + 1e-10)
+
+        return jqt.Qarray.create(normalized_amplitudes)
+
+    def hermcompanion(self, c, dim):
+        """Return the scaled companion matrix of c.
+
+        The basis polynomials are scaled so that the companion matrix is
+        symmetric when `c` is an Hermite basis polynomial. This provides
+        better eigenvalue estimates than the unscaled case and for basis
+        polynomials the eigenvalues are guaranteed to be real if
+        `jax.numpy.linalg.eigvalsh` is used to obtain them.
+
+        Parameters
+        ----------
+        c : array_like
+            1-D array of Hermite series coefficients ordered from low to high
+            degree.
+
+        Returns
+        -------
+        mat : ndarray
+            Scaled companion matrix of dimensions (deg, deg).
+
+        """
+        n = dim - 1
+        mat = jnp.zeros((n, n), dtype=c.dtype)
+        scl = jnp.hstack((1.0, 1.0 / jnp.sqrt(2.0 * jnp.arange(n - 1, 0, -1))))
+        scl = jnp.cumprod(scl)[::-1]
+        shp = mat.shape
+        mat = mat.flatten()
+        mat = mat.at[1:: n + 1].set(jnp.sqrt(0.5 * jnp.arange(1, n)))
+        mat = mat.at[n:: n + 1].set(jnp.sqrt(0.5 * jnp.arange(1, n)))
+        mat = mat.reshape(shp)
+        mat = mat.at[:, -1].add(-scl * c[:-1] / (2.0 * c[-1]))
+        return mat
+
+
+    def hermroots(self, n, dim):
+        r"""Compute the roots of a Hermite series.
+
+        Return the roots (a.k.a. "zeros") of the polynomial
+
+        .. math:: p(x) = \sum_i c[i] * H_i(x).
+
+        Parameters
+        ----------
+        c : 1-D array_like
+            1-D array of coefficients.
+
+        Returns
+        -------
+        out : ndarray
+            Array of the roots of the series. If all the roots are real,
+            then `out` is also real, otherwise it is complex.
+
+        See Also
+        --------
+        orthax.polynomial.polyroots
+        orthax.legendre.legroots
+        orthax.laguerre.lagroots
+        orthax.chebyshev.chebroots
+        orthax.hermite_e.hermeroots
+
+        Notes
+        -----
+        The root estimates are obtained as the eigenvalues of the companion
+        matrix, Roots far from the origin of the complex plane may have large
+        errors due to the numerical instability of the series for such
+        values. Roots with multiplicity greater than 1 will also show larger
+        errors as the value of the series near such points is relatively
+        insensitive to errors in the roots. Isolated roots near the origin can
+        be improved by a few iterations of Newton's method.
+
+        The Hermite series basis polynomials aren't powers of `x` so the
+        results of this function may seem unintuitive.
+
+        Examples
+        --------
+        from orthax.hermite import hermroots, hermfromroots
+        coef = hermfromroots([-1, 0, 1])
+        coef
+        array([0.   ,  0.25 ,  0.   ,  0.125])
+        hermroots(coef)
+        array([-1.00000000e+00, -1.38777878e-17,  1.00000000e+00])
+
+        """
+        if n + 1 <= 1:
+            return jnp.array([])
+        if n + 1 == 2:
+            return jnp.array([0])
+
+        c = one_hot(n, dim)
+
+        # rotated companion matrix reduces error
+        m = self.hermcompanion(c, dim)[::-1, ::-1]
+        r = jnp.linalg.eigvalsh(m)
+        r = jnp.sort(r)
+        return r
+
     def _get_basis_z(self) -> Tuple[jqt.Qarray, jqt.Qarray]:
         """
         Construct basis states |+-x>, |+-y>, |+-z>.
-        step 1: use ideal GKP stabilizers to find ideal GKP |+z> state
-        step 2: make ideal eigenvector finite energy
-            We want the groundstate of H = E H_0 E⁻¹.
-            So, we can begin by find the groundstate of H_0 -> |λ₀⟩
-            Then, we know that E|λ₀⟩ = |λ⟩ is the groundstate of H.
-            pf. H|λ⟩ = (E H_0 E⁻¹)(E|λ₀⟩) = E H_0 |λ₀⟩ = λ₀ (E|λ₀⟩) = λ₀|λ⟩
-
-        TODO (if necessary):
-            Alternatively, we could construct a hamiltonian using
-            finite energy stabilizers S_x, S_y, S_z, Z_s. However,
-            this would make H = - S_x - S_y - S_z - Z_s non-hermitian.
-            Currently, JAX does not support derivatives of jnp.linalg.eig,
-            while it does support derivatives of jnp.linalg.eigh.
-            Discussion: https://github.com/google/jax/issues/2748
         """
 
-        # step 1: use ideal GKP stabilizers to find ideal GKP |+z> state
-        H_0 = (
-            -self.common_gates["S_x_0"]
-            - self.common_gates["S_y_0"]
-            - self.common_gates["S_z_0"]
-            - self.common_gates["Z_s_0"]  # bosonic |+z> state
-        )
-
-        _, vecs = jnp.linalg.eigh(H_0.data)
-        gstate_ideal = jqt.Qarray.create(vecs[:, 0])
-
-        # step 2: make ideal eigenvector finite energy
-        gstate = self.common_gates["E"] @ gstate_ideal
-
-        plus_z = jqt.unit(gstate)
-        minus_z = jqt.unit(self.common_gates["X"] @ plus_z)
+        plus_z = self._finite_gkp(0, self.params["delta"], self.params[
+            "N"])
+        minus_z = self._finite_gkp(1, self.params["delta"], self.params[
+            "N"])
         return plus_z, minus_z
 
     # utils

--- a/jaxquantum/core/qp_distributions.py
+++ b/jaxquantum/core/qp_distributions.py
@@ -1,7 +1,9 @@
 import jax.numpy as jnp
-from jax import vmap
+from jax import vmap, config
 from jax.scipy.special import factorial
 import jax
+
+config.update("jax_enable_x64", True)
 
 def wigner(psi, xvec, yvec, method="clenshaw", g=2):
     """Wigner function for a state vector or density matrix at points
@@ -85,7 +87,7 @@ def wigner(psi, xvec, yvec, method="clenshaw", g=2):
         raise TypeError("method must be either 'iterative', 'laguerre', or 'fft'.")
 
 
-def _wigner_clenshaw(rho, xvec, yvec, g=jnp.sqrt(2)):
+def _wigner_clenshaw(rho, xvec, yvec, g):
     r"""
     Using Clenshaw summation - numerically stable and efficient
     iterative algorithm to evaluate polynomial series.


### PR DESCRIPTION
Construct GKP basis states explicitly instead of via diagonalization. This methods yields faster execution, and much more precise states (6 nines of logical expectation vs about 1 or 2 of the old method).

Closese #26 